### PR TITLE
[Chore] Rewrite if statement to make it more efficient

### DIFF
--- a/src/DevStatusController.php
+++ b/src/DevStatusController.php
@@ -37,11 +37,9 @@ class DevStatusController extends Controller {
 
     if($public_repos <= 10){
        $status = "Rookie";
-    }
-    if( $public_repos > 10 && $public_repos <= 25){
+    } elseif ( $public_repos > 10 && $public_repos <= 25) {
        $status = "Intermediate";
-    }
-    if( $public_repos > 25){
+    } elseif ( $public_repos > 25) {
        $status = "Ninja";
     }
 


### PR DESCRIPTION
If I'm not mistaken, the if statements as written would all be checked even if the first condition were satisfied (that is, if public_repos == 5).

So, unless I've overlooked something (I'm still learning PHP), the statements should either return at that point if no further execution is desired, or the statements should be rewritten using else conditions.
